### PR TITLE
updated to work with conduit >= 1.0

### DIFF
--- a/Data/Conduit/Bits.hs
+++ b/Data/Conduit/Bits.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BangPatterns, NoMonomorphismRestriction #-}
 
 module Data.Conduit.Bits (
   -- * Conduits
@@ -17,7 +17,7 @@ import Data.Conduit
 import qualified Data.Conduit.Binary as CB
 
 -- | Bitstream decoder
-decodeBits :: Monad m => GLConduit S.ByteString m Bool
+decodeBits :: Monad m => Conduit S.ByteString m Bool
 decodeBits = go where
   go = do
     mb <- CB.head
@@ -29,10 +29,11 @@ decodeBits = go where
         go
 
 -- | Bitstream encoder
-encodeBits :: Monad m => GConduit Bool m S.ByteString
+encodeBits :: Monad m => Conduit Bool m S.ByteString
 encodeBits = go where
   go = do
     mb <- awaitBits 8
+        
     case mb of
       Nothing -> return ()
       Just b8 -> do
@@ -40,13 +41,13 @@ encodeBits = go where
         go
 
 -- | Yields specified amount of bits (LSB first)
-yieldBits :: (Bits b, Monad m) => b -> Int -> GSource m Bool
+yieldBits :: (Bits b, Monad m) => b -> Int -> Producer m Bool
 yieldBits b n =
   forM_ [0..n-1] $ \i -> yield $ testBit b i
 {-# INLINEABLE yieldBits #-}
 
 -- | await specified amount of bits (LSB first)
-awaitBits :: (Bits b, Monad m) => Int -> GSink Bool m (Maybe b)
+awaitBits :: (Bits b, Monad m) => Int -> Consumer Bool m (Maybe b)
 awaitBits n = go 0 0 where
   go !acc !i
     | i == n = return $ Just acc

--- a/bits-conduit.cabal
+++ b/bits-conduit.cabal
@@ -20,8 +20,8 @@ library
 
   build-depends:       base       ==4.5.*
                      , mtl        >=2.1
-                     , bytestring >=0.9.2
-                     , conduit    ==0.5.*
+                     , bytestring
+                     , conduit    >=1.0
 
 test-suite bits-conduit-test
   type:                exitcode-stdio-1.0

--- a/bits-conduit.cabal
+++ b/bits-conduit.cabal
@@ -1,5 +1,5 @@
 name:                bits-conduit
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            Bitstream support for Conduit
 description:         Bitstream support for Conduit
 license:             BSD3


### PR DESCRIPTION
First commit (SHA: 2ea3da99aa7ef5f197fff650d930605628566ecd): 
Updated Type signutures to work with upstream version of conduit. (>= 1.0)

In the second commit (SHA: 78ccd4ee4af0f6111a4dd187f3e7be4f6e297e1e) there is a version bump to 0.3.0.0 of bits-conduit.
